### PR TITLE
Workflow file to track traffic

### DIFF
--- a/.github/workflows/traffic.yml
+++ b/.github/workflows/traffic.yml
@@ -72,12 +72,6 @@ jobs:
                       s#^https://github\.com/##;
                       s#\.git$##
                   ')
-
-
-                  if [ "$repo" = "mpi-advance/MPIPCL" ] || [ "$repo" = "mpi-advance/stream-triggering" ]; then
-                      echo "Skipping $repo (temporarily excluded)"
-                      continue
-                  fi
                   
                   echo "Collecting $repo Traffic"
                   collect_repo "$repo"

--- a/.github/workflows/traffic.yml
+++ b/.github/workflows/traffic.yml
@@ -62,6 +62,7 @@ jobs:
 
               # Each is a key/value pair, so get path for each
               while read -r key path; do
+               
                   # For each path, find the URL
                   url=$(git config --file .gitmodules --get "submodule.$path.url")
 
@@ -72,6 +73,12 @@ jobs:
                       s#\.git$##
                   ')
 
+
+                  if [ "$repo" = "mpi-advance/MPIPCL" ]; then
+                      echo "Skipping $repo (temporarily excluded)"
+                      continue
+                  fi
+                  
                   echo "Collecting $repo Traffic"
                   collect_repo "$repo"
               done <<< "$PATHS"

--- a/.github/workflows/traffic.yml
+++ b/.github/workflows/traffic.yml
@@ -75,7 +75,7 @@ jobs:
                   echo "Collecting $repo Traffic"
                   collect_repo "$repo"
               done <<< "$PATHS"
-
+          fi
 
       - name: Commit and push
         run: |

--- a/.github/workflows/traffic.yml
+++ b/.github/workflows/traffic.yml
@@ -1,0 +1,87 @@
+name: Track Traffic
+on:
+  schedule:
+    - cron: "0 6 * * *" # Runs at 06:00, every day
+  workflow_dispatch:      # Or can manually run
+permissions:
+  contents: write
+  actions: read
+jobs:
+  capture-traffic:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          ref: track-traffic
+          submodules: 'false'
+      - name: Get yesterday's clone traffic
+        id: clones
+        env:
+          GH_TOKEN: ${{ secrets.TRAFFIC_SECRET }}
+        run: |
+          METRICS_DIR=".github/metrics"
+          mkdir -p $METRICS_DIR
+          
+          # yesterday's clones have date = `yesterday`
+          YESTERDAY=$(date -I -d "yesterday")
+          echo $YESTERDAY
+
+          collect_repo () {
+              local FULL_REPO="$1"
+              local REPO_NAME="${FULL_REPO##*/}"
+              local OUTPUT="$METRICS_DIR/${REPO_NAME}.csv"
+              if [ ! -f $OUTPUT ]; then
+                echo "date,repo,daily_clones,daily_unique_cloners" > $OUTPUT
+              fi
+
+              # get all traffic from yesterday
+              DAILY_JSON=$(gh api repos/${FULL_REPO}/traffic/clones \
+                --jq ".clones[] | select(.timestamp | startswith(\"$YESTERDAY\"))")
+              echo $DAILY_JSON
+
+              # get total clone count and unique clone count
+              DAILY_COUNT=$(echo "$DAILY_JSON" | jq -r '.count // 0')
+              echo $DAILY_COUNT
+              DAILY_UNIQUES=$(echo "$DAILY_JSON" | jq -r '.uniques // 0')
+              echo $DAILY_UNIQUES
+
+              # Output variables date, count, and uniques to next step
+              echo $YESTERDAY, $DAILY_COUNT, $DAILY_UNIQUES >> "$OUTPUT"
+          }
+
+          # Gather Traffic About MPI Advance Repo
+          echo "Collecting $GITHUB_REPOSITORY Traffic"
+          collect_repo "$GITHUB_REPOSITORY"
+
+          # Step through each submodule
+          if [ -f .gitmodules ]; then
+              # Get all paths in .gitmodules file
+              PATHS=$(git config --file .gitmodules --get-regexp path)
+
+              # Each is a key/value pair, so get path for each
+              while read -r key path; do
+                  # For each path, find the URL
+                  url=$(git config --file .gitmodules --get "submodule.$path.url")
+
+                  # Find the submodule name (mpi-advance/<submodule>)
+                  repo=$(echo "$url" | sed -E '
+                      s#^git@github\.com:##;
+                      s#^https://github\.com/##;
+                      s#\.git$##
+                  ')
+
+                  echo "Collecting $repo Traffic"
+                  collect_repo "$repo"
+              done <<< "$PATHS"
+
+
+      - name: Commit and push
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+
+          git add .github/metrics/*.csv
+          git commit -m "Daily clone stats (${{ steps.clones.outputs.date }})" || echo "No changes"
+          git push origin HEAD:track-traffic

--- a/.github/workflows/traffic.yml
+++ b/.github/workflows/traffic.yml
@@ -74,7 +74,7 @@ jobs:
                   ')
 
 
-                  if [ "$repo" = "mpi-advance/MPIPCL" ]; then
+                  if [ "$repo" = "mpi-advance/MPIPCL" ] || [ "$repo" = "mpi-advance/stream-triggering" ]; then
                       echo "Skipping $repo (temporarily excluded)"
                       continue
                   fi


### PR DESCRIPTION
# Short Description

Will gather clone and unique clone data for the mpi-advance repo along with from each of its submodules.  The new workflow file traffic.yml will run every day at 6am, grabbing the previous day's numbers.  Each will be saved into a separate CSV file in .github/metrics of a track-traffic branch.

TODO: Before this can be merged into the main branch of mpi-advance, someone with access to all three submodules (@TheMasterDirk?) needs to create a secret key (secrets.TRAFFIC_SECRET).

TODO: Before running the workflow, we need to also make one additional branch in mpi-advance called 'track-traffic' without push restrictions (the bot cannot push to the main branch due to the pull request requirement).

# Files Affected
New workflow: traffic.yml

